### PR TITLE
added range quantile queries to both wavelet tree implementations.

### DIFF
--- a/trunk/src/static/sequence/WaveletTree.cpp
+++ b/trunk/src/static/sequence/WaveletTree.cpp
@@ -115,9 +115,22 @@ namespace cds_static
         return am->unmap(root->access(pos));
     }
 
+    uint WaveletTree::quantile(size_t left,size_t right,uint q) const
+    {
+        return quantile_freq(left,right,q).first;
+    }
+    
+    pair<uint,size_t> WaveletTree::quantile_freq(size_t left,size_t right,uint q) const
+    {
+        /* q=1 -> q=0 */
+        q--;
+
+        pair<uint,size_t> res = root->quantile_freq(left,right,q);
+        return std::make_pair( am->unmap(res.first) , res.second );
+    }
+
     uint WaveletTree::access(size_t pos, size_t &rank) const
     {
-        cout << ".";
         return root->access(pos, rank);
     }
 

--- a/trunk/src/static/sequence/WaveletTree.h
+++ b/trunk/src/static/sequence/WaveletTree.h
@@ -79,6 +79,11 @@ namespace cds_static
             virtual uint access(size_t pos) const;
             virtual uint access(size_t pos, size_t &rank) const;
 
+            /* find the q-th smallest element in T[l..r] */
+            uint quantile(size_t left,size_t right,uint q) const;
+            /* find the q-th smallest element in T[l..r] and return it's freq */
+            pair<uint,size_t> quantile_freq(size_t left,size_t right,uint q) const;
+
             virtual size_t count(uint s) const;
 
             virtual size_t getSize() const;

--- a/trunk/src/static/sequence/WaveletTreeNoptrs.h
+++ b/trunk/src/static/sequence/WaveletTreeNoptrs.h
@@ -69,6 +69,12 @@ namespace cds_static
             virtual uint access(size_t pos) const;
             virtual size_t getSize() const;
 
+            /* find the q-th smallest element in T[l..r] */
+            virtual uint quantile(size_t left,size_t right,uint q);
+
+            /* find the q-th smallest element in T[l..r] and return the freq */
+            pair<uint32_t,size_t> quantile_freq(size_t left,size_t right,uint q);
+
             virtual size_t count(uint symbol) const;
 
             virtual void save(ofstream & fp) const;

--- a/trunk/src/static/sequence/wt_node.h
+++ b/trunk/src/static/sequence/wt_node.h
@@ -45,6 +45,7 @@ namespace cds_static
             virtual ~wt_node() {}
             virtual size_t rank(uint symbol, size_t pos, uint l, wt_coder * c) const = 0;
             virtual size_t select(uint symbol, size_t pos, uint l, wt_coder * c) const = 0;
+            virtual pair<uint,size_t> quantile_freq(size_t left,size_t right,uint q) const = 0;
             virtual uint access(size_t pos) const = 0;
             virtual uint access(size_t pos, size_t & rankp) const = 0;
             virtual size_t getSize() const = 0;

--- a/trunk/src/static/sequence/wt_node_internal.cpp
+++ b/trunk/src/static/sequence/wt_node_internal.cpp
@@ -219,6 +219,24 @@ namespace cds_static
         }
     }
 
+    pair<uint,size_t> wt_node_internal::quantile_freq(size_t left,size_t right,uint q) const
+    {
+        /* number of 1s before T[l..r] */
+        size_t rank_before_left = bitmap->rank1(left-1);
+        /* number of 1s before T[r] */
+        size_t rank_before_right = bitmap->rank1(right);
+        /* number of 1s in T[l..r] */
+        size_t num_ones = rank_before_right - rank_before_left;
+        /* number of 0s in T[l..r] */
+        size_t num_zeros = (right-left+1) - num_ones;
+
+        if(q >= num_zeros) {
+            return right_child->quantile_freq(rank_before_left,rank_before_left+num_ones-1,q-num_zeros);
+        } else {
+            return left_child->quantile_freq((left-rank_before_left),(left-rank_before_left)+num_zeros-1,q);
+        }
+    }
+
     size_t wt_node_internal::getSize() const
     {
         uint s = bitmap->getSize()+sizeof(wt_node_internal);

--- a/trunk/src/static/sequence/wt_node_internal.h
+++ b/trunk/src/static/sequence/wt_node_internal.h
@@ -44,6 +44,7 @@ namespace cds_static
             virtual size_t rank(uint symbol, size_t pos, uint level, wt_coder * c) const;
             //virtual size_t rankLessThan(uint &symbol, size_t pos) const;
             virtual size_t select(uint symbol, size_t pos, uint level, wt_coder * c) const;
+            virtual pair<uint,size_t> quantile_freq(size_t left,size_t right,uint q) const;
             virtual uint access(size_t pos) const;
             virtual uint access(size_t pos, size_t & rankp) const;
             virtual size_t getSize() const;

--- a/trunk/src/static/sequence/wt_node_leaf.cpp
+++ b/trunk/src/static/sequence/wt_node_leaf.cpp
@@ -60,6 +60,11 @@ namespace cds_static
         return symbol;
     }
 
+    pair<uint,size_t> wt_node_leaf::quantile_freq(size_t left,size_t right,uint q) const
+    {
+        return std::make_pair(symbol,right-left+1);
+    }
+
     size_t wt_node_leaf::getSize() const
     {
         return sizeof(wt_node_leaf);

--- a/trunk/src/static/sequence/wt_node_leaf.h
+++ b/trunk/src/static/sequence/wt_node_leaf.h
@@ -42,6 +42,7 @@ namespace cds_static
             virtual ~wt_node_leaf();
             virtual size_t rank(uint symbol, size_t pos, uint l, wt_coder * c) const;
             virtual size_t select(uint symbol, size_t pos, uint l, wt_coder * c) const;
+            virtual pair<uint,size_t> quantile_freq(size_t left,size_t right,uint q) const;
             virtual uint access(size_t pos) const;
             virtual uint access(size_t pos, size_t &rank) const;
             virtual size_t getSize() const;

--- a/trunk/tests/Makefile
+++ b/trunk/tests/Makefile
@@ -6,8 +6,8 @@ CPP=g++
 INCS=-I../includes/
 LIB=../lib/libcds.a
 
-OBJECTS= testArray.o testBitSequence.o testSequence.o testHuffman.o testTextIndex.o testLCP.o testNPR.o testSuffixTree.o timeSequence.o toArray.o toArray2.o
-BIN= testArray testBitSequence testSequence testHuffman testTextIndex testLCP testNPR testSuffixTree timeSequence toArray toArray2
+OBJECTS= testArray.o testBitSequence.o testSequence.o testQuantile.o testHuffman.o testTextIndex.o testLCP.o testNPR.o testSuffixTree.o timeSequence.o toArray.o toArray2.o
+BIN= testArray testBitSequence testSequence testHuffman testTextIndex testLCP testNPR testSuffixTree timeSequence toArray toArray2 testQuantile
 
 %.o: %.cpp
 	@echo " [C++] Compiling $<"
@@ -24,6 +24,10 @@ testHuffman:
 testSequence:
 	@echo " [LNK] Building testSequence"
 	@$(CPP) $(CPPFLAGS) -o testSequence testSequence.o $(LIB)
+
+testQuantile:
+	@echo " [LNK] Building testSequence"
+	@$(CPP) $(CPPFLAGS) -o testQuantile testQuantile.o $(LIB)
 
 testBitSequence:
 	@echo " [LNK] Building testBitSequence"

--- a/trunk/tests/testQuantile.cpp
+++ b/trunk/tests/testQuantile.cpp
@@ -1,0 +1,124 @@
+
+#include <cstdlib>
+
+#include <libcdsBasics.h>
+#include <BitSequence.h>
+#include <Mapper.h>
+#include <Sequence.h>
+
+using namespace std;
+using namespace cds_static;
+
+
+int uintcmp(const void* a,const void* b)
+{
+    return (*(const uint32_t*)a - *(const uint32_t*)b);
+}
+
+void testQuantileWT(Array& a,WaveletTree& wt)
+{
+    size_t N = 500;
+    /* select 500 rand ranges and perform quantile queries */
+    while(N) {
+        size_t start = rand() % a.getLength();
+        size_t len = (rand() % (a.getLength() - start)) % 10;
+
+        /* copy and sort the array */
+        uint32_t* A = new uint32_t[len+1];
+        for(size_t i=0;i<=len;i++) {
+            A[i] = a[start+i];
+        };
+        qsort(A,len+1,sizeof(uint32_t),uintcmp);
+
+        /* test */
+        size_t accum = 0;
+        size_t quantile = 1;
+        while(accum <= len) {
+            pair<uint,size_t> qf = wt.quantile_freq(start,start+len,quantile);
+            for(size_t i=0;i<qf.second;i++) {
+                if(A[accum+i] != qf.first) {
+                    fprintf(stderr,"ERROR!\n");
+                    exit(EXIT_FAILURE);
+                }
+            }
+            accum += qf.second;
+            quantile += qf.second;
+        }
+
+        /* cleanup */
+        N--;
+        delete [] A;
+    }
+
+}
+
+void testQuantileWTNPTR(Array& a,WaveletTreeNoptrs& wt)
+{
+    size_t N = 500;
+    /* select 500 rand ranges and perform quantile queries */
+    while(N) {
+        size_t start = rand() % a.getLength();
+        size_t len = rand() % (a.getLength() - start);
+
+        /* copy and sort the array */
+        uint32_t* A = new uint32_t[len+1];
+        for(size_t i=0;i<=len;i++) {
+            A[i] = a[start+i];
+        };
+        qsort(A,len+1,sizeof(uint32_t),uintcmp);
+
+
+        /* test */
+        size_t accum = 0;
+        size_t quantile = 1;
+        while(accum <= len) {
+            pair<uint,size_t> qf = wt.quantile_freq(start,start+len,quantile);
+            for(size_t i=0;i<qf.second;i++) {
+                if(A[accum+i] != qf.first) {
+                    fprintf(stderr,"ERROR!\n");
+                    exit(EXIT_FAILURE);
+                }
+            }
+            accum += qf.second;
+            quantile += qf.second;
+        }
+
+        /* cleanup */
+        N--;
+        delete [] A;
+    }
+}
+
+int main(int argc, char ** argv) {
+
+  size_t len = rand() % 200; 
+  uint maxv = 50 + rand() % 50;
+
+  Array a(len,maxv);
+  for(uint i=0;i<len;i++) {
+    a.setField(i,rand()%maxv);
+  }
+  
+  Mapper * mapper = new MapperCont(a, BitSequenceBuilderRG(20));
+  Mapper * mapper2 = new MapperNone();
+  mapper->use();
+  mapper2->use();
+  cout << "Test 1 : Wavelet tree with pointers" << endl;
+  /*WaveletTree wt1(a,new wt_coder_huff(a, mapper),new BitSequenceBuilderDArray(), mapper);*/
+  WaveletTree wt1(a,new wt_coder_binary(a, mapper),new BitSequenceBuilderRG(20), mapper);
+  cout << "bs.size() = " << wt1.getSize() << endl;
+
+  testQuantileWT(a, wt1);
+
+  cout << "Test 2 : Wavelet tree without pointers" << endl;
+  WaveletTreeNoptrs wt3(a, new BitSequenceBuilderRRR(32), mapper);
+  cout << "bs.size() = " << wt3.getSize() << endl;
+  testQuantileWTNPTR(a, wt3);
+  mapper->unuse();
+  mapper2->unuse();
+
+  fprintf(stdout,"ALL OK\n");
+
+  return 0;
+}
+


### PR DESCRIPTION
some functionality I'm using in my local libcds fork. (more to come)
- Range Quantile Queries as described in: Travis Gagie, Simon J. Puglisi, Andrew Turpin: Range Quantile Queries: Another Virtue of Wavelet Trees. SPIRE 2009: 1-6. added. 
- Example: find the q-th smallest element in T[l..r]: WaveletTree::quantile(l,r,q);
- Example: find the q-th smallest element in T[l..r] and return it's freqency: pair<uint32_t,size_t> WaveletTree::quantile_freq(l,r,q)
- testQuantile.cpp includes some basic testing of the two functions.

Note: does NOT work on huffman shaped wavelet trees.
