### PR TITLE
Faster WaveletTreeNoptrs::rank(): save up to log(sigma) binary rank rank operations.

### DIFF
--- a/trunk/src/static/sequence/WaveletTreeNoptrs.cpp
+++ b/trunk/src/static/sequence/WaveletTreeNoptrs.cpp
@@ -338,18 +338,23 @@ namespace cds_static
         size_t start=0;
         size_t end=n-1;
         size_t count=0;
+        size_t before=0;
         while(level<height) {
+            if(start==0) before = 0;
+            else before = bitstring[level]->rank1(start-1);
+
             if(is_set(symbol,level)) {
-                pos=bitstring[level]->rank1(pos)-bitstring[level]->rank1(start-1)-1;
+                pos=bitstring[level]->rank1(pos)-before-1;
                 count=pos+1;
-                start=(bitstring[level]->rank1(end)-bitstring[level]->rank1(start-1));
+                start=(bitstring[level]->rank1(end)-before);
                 start=end-start+1;
                 pos+=start;
             }
             else {
-                pos=pos-start+bitstring[level]->rank1(start-1)-bitstring[level]->rank1(pos);
+                pos=pos-start+bitstring[level]->rank1(start-1)-
+                    bitstring[level]->rank1(pos);
                 count=pos+1;
-                end=end-start-(bitstring[level]->rank1(end)-bitstring[level]->rank1(start-1));
+                end=end-start-(bitstring[level]->rank1(end)-before);
                 end+=start;
                 pos+=start;
             }


### PR DESCRIPTION
In WaveletTreeNoptrs::rank() bitstring[level]->rank1(start-1) is calculated twice. Storing it is more efficient.
