### PR TITLE
Save length on disk.

### DIFF
--- a/src/static/sequence/WaveletTreeNoptrs.cpp
+++ b/src/static/sequence/WaveletTreeNoptrs.cpp
@@ -233,6 +233,7 @@ namespace cds_static
 		uint wr = WVTREE_NOPTRS_HDR;
 		saveValue(fp, wr);
 		saveValue<size_t>(fp,n);
+		saveValue<size_t>(fp,length);
 		saveValue(fp, max_v);
 		saveValue(fp, height);
 		am->save(fp);
@@ -246,7 +247,7 @@ namespace cds_static
 		if (rd != WVTREE_NOPTRS_HDR) return NULL;
 		WaveletTreeNoptrs * ret = new WaveletTreeNoptrs();
 		ret->n = loadValue<size_t>(fp);
-		ret->length = ret->n;
+		ret->length = loadValue<size_t>(fp);
 		ret->max_v = loadValue<uint>(fp);
 		ret->height = loadValue<uint>(fp);
 		ret->am = Mapper::load(fp);


### PR DESCRIPTION
When saving WaveletTreeNoptrs, length is not saved assuming that it's equal to n, but sometimes it's not. Therefore it doesn't work correctly when loading the data structure from disk.
