### PR TITLE
Fix build on OSX 10.9

### DIFF
--- a/src/static/coders/huff.cpp
+++ b/src/static/coders/huff.cpp
@@ -170,7 +170,7 @@ namespace cds_static
 		code += pos;
 		if (d > W) { bitzero(stream,ptr,d-W); ptr += d-W; d = W; }
 		while (d--) {
-			if ((code >> d) & 1) bitset(stream,ptr);
+			if ((code >> d) & 1) cds_utils::bitset(stream,ptr);
 			else bitclean(stream,ptr);
 			ptr++;
 		}

--- a/src/static/permutation/PermutationWT.cpp
+++ b/src/static/permutation/PermutationWT.cpp
@@ -31,12 +31,12 @@ namespace cds_static
 		runs = 0;
 		uint last = get_field(perm,b,0);
 		seq[get_field(perm,b,0)] = 0;
-		bitset(marker,0);
+		cds_utils::bitset(marker,0);
 
 		for(size_t i=1;i<len;i++) {
 			if(last > get_field(perm,b,i)) {
 				runs++;
-				bitset(marker,i);
+				cds_utils::bitset(marker,i);
 			}
 			seq[get_field(perm,b,i)] = runs;
 			last = get_field(perm,b,i);

--- a/src/static/permutation/perm.cpp
+++ b/src/static/permutation/perm.cpp
@@ -65,24 +65,24 @@ namespace cds_static
 				if (bitget(baux,i) == 0) {
 					nextelem = j = bptr = antbptr = i;
 					aux = 0;
-					bitset(baux, j);
+          cds_utils::bitset(baux, j);
 					cyclesize = 0;
 					while ((elem=get_field(elems,nbits,j)) != nextelem) {
 						j = elem;
-						bitset(baux, j);
+            cds_utils::bitset(baux, j);
 						aux++;
 						if (aux >= t) {
 							nbwdptrs++;
 							antbptr = bptr;
 							bptr    = j;
 							aux     = 0;
-							bitset(b, j);
+              cds_utils::bitset(b, j);
 						}
 						cyclesize++;
 					}
 					if (cyclesize >= t) {
 						nbwdptrs++;
-						bitset(b, nextelem);
+            cds_utils::bitset(b, nextelem);
 					}
 				}
 			}
@@ -97,11 +97,11 @@ namespace cds_static
 				if (bitget(baux,i) == 0) {
 					nextelem = j = bptr = antbptr = i;
 					aux = 0;
-					bitset(baux, j);
+          cds_utils::bitset(baux, j);
 					cyclesize = 0;
 					while ((elem=get_field(elems,nbits,j)) != nextelem) {
 						j = elem;
-						bitset(baux, j);
+            cds_utils::bitset(baux, j);
 						aux++;
 						if (aux >= t) {
 							auxbwdptr[nbwdptrs].key = j;
@@ -109,14 +109,14 @@ namespace cds_static
 							antbptr = bptr;
 							bptr    = j;
 							aux     = 0;
-							bitset(b, j);
+              cds_utils::bitset(b, j);
 						}
 						cyclesize++;
 					}
 					if (cyclesize >= t) {
 						auxbwdptr[nbwdptrs].key = nextelem;
 						auxbwdptr[nbwdptrs++].pointer = bptr;
-						bitset(b, nextelem);
+            cds_utils::bitset(b, nextelem);
 					}
 				}
 			}

--- a/src/static/sequence/BitmapsSequence.cpp
+++ b/src/static/sequence/BitmapsSequence.cpp
@@ -50,7 +50,7 @@ namespace cds_static
 			for(uint j=0;j<uint_len(n,1);j++)
 				bm[j]=0;
 			while(pp<occ[i]) {
-				bitset(bm,pos[pp]);
+				cds_utils::bitset(bm,pos[pp]);
 				pp++;
 			}
 			bitmaps[i] = bsb->build(bm,length);
@@ -98,7 +98,7 @@ namespace cds_static
 			for(uint j=0;j<uint_len(length,1);j++)
 				bm[j]=0;
 			while(pp<occ[i]) {
-				bitset(bm,pos[pp]);
+				cds_utils::bitset(bm,pos[pp]);
 				pp++;
 			}
 			//cout << "build " << bm << " len=" << length << " i=" << i << endl;

--- a/src/static/sequence/SequenceGMR.cpp
+++ b/src/static/sequence/SequenceGMR.cpp
@@ -107,7 +107,7 @@ namespace cds_static
 		uint pos=0;
 		for (unsigned long long i=0;i<(unsigned long long)num_chunks*sigma;i++) {
 			for (uint j=0;j<ones[i];j++) {
-				bitset(B_bitmap, pos);
+				cds_utils::bitset(B_bitmap, pos);
 				pos++;
 			}
 			pos++;

--- a/src/static/sequence/SequenceGMRChunk.cpp
+++ b/src/static/sequence/SequenceGMRChunk.cpp
@@ -49,7 +49,7 @@ namespace cds_static
 		for(uint c=0;c<sigma;c++) {
 			X_pos++;
 			for(uint i=0;i<counter[c+1];i++) {
-				bitset(X_bitmap, X_pos);
+				cds_utils::bitset(X_bitmap, X_pos);
 				X_pos++;
 			}
 			counter[c+1]+=counter[c];
@@ -95,7 +95,7 @@ namespace cds_static
 		for(uint c=0;c<sigma;c++) {
 			X_pos++;
 			for(uint i=0;i<counter[c+1];i++) {
-				bitset(X_bitmap, X_pos);
+				cds_utils::bitset(X_bitmap, X_pos);
 				X_pos++;
 			}
 			counter[c+1]+=counter[c];

--- a/src/static/sequence/WaveletMatrix.cpp
+++ b/src/static/sequence/WaveletMatrix.cpp
@@ -334,7 +334,7 @@ namespace cds_static
 				}
 				else {
 					new_symbols[new_pos1++] = symbols[i];
-					bitset(bm[level], i);
+					cds_utils::bitset(bm[level], i);
 				}
 			}
 			delete [] symbols;

--- a/src/static/sequence/WaveletTreeNoptrs.cpp
+++ b/src/static/sequence/WaveletTreeNoptrs.cpp
@@ -493,7 +493,7 @@ namespace cds_static
 				bitclean(bm[level], offset + i);
 			} else {
 				right[cright++] = symbols[i];
-				bitset(bm[level], offset + i);
+				cds_utils::bitset(bm[level], offset + i);
 			}
 		}
 
@@ -530,7 +530,7 @@ namespace cds_static
 			}
 			else {
 				set_field(right, width, cright++, get_field(symbols, width, i));
-				bitset(bm[level], offset + i);
+				cds_utils::bitset(bm[level], offset + i);
 			}
 		}
 

--- a/src/static/sequence/WaveletTreeNoptrsS.cpp
+++ b/src/static/sequence/WaveletTreeNoptrsS.cpp
@@ -68,8 +68,8 @@ namespace cds_static
         for(uint i=0;i<(new_n+1)/W+1;i++)
             oc[i] = 0;
         for(uint i=0;i<=max_v;i++)
-            bitset(oc,occurrences[i]-1);
-        bitset(oc,new_n);
+            cds_utils::bitset(oc,occurrences[i]-1);
+        cds_utils::bitset(oc,new_n);
         occ = bmb->build(oc,new_n+1);
         delete [] occurrences;
         this->n = new_n;
@@ -136,8 +136,8 @@ namespace cds_static
         for(uint i=0;i<(new_n+1)/W+1;i++)
             oc[i] = 0;
         for(uint i=0;i<=max_v;i++)
-            bitset(oc,occurrences[i]-1);
-        bitset(oc,new_n);
+            cds_utils::bitset(oc,occurrences[i]-1);
+        cds_utils::bitset(oc,new_n);
         occ = bmb->build(oc,new_n+1);
         delete [] occurrences;
         this->n = new_n;
@@ -355,7 +355,7 @@ namespace cds_static
                 } else {
                     //cout << "[" << new_pos1 << "]=" << symbols[i] << endl;
                     new_symbols[new_pos1++] = symbols[i];
-                    bitset(bm[level], i);
+                    cds_utils::bitset(bm[level], i);
                 }
             }
             delete [] symbols;

--- a/src/static/sequence/wt_node_internal.cpp
+++ b/src/static/sequence/wt_node_internal.cpp
@@ -31,7 +31,7 @@ namespace cds_static
             ibitmap[i]=0;
         for(uint i=0;i<n;i++) {
             if(c->is_set(symbols[i],l))
-                bitset(ibitmap,i);
+                cds_utils::bitset(ibitmap,i);
         }
         bitmap = bmb->build(ibitmap, n);
         delete [] ibitmap;
@@ -84,7 +84,7 @@ namespace cds_static
             ibitmap[i]=0;
         for(size_t i=0;i<n;i++)
             if(c->is_set((uint)symbols[i + left],l))
-                bitset(ibitmap,i);
+                cds_utils::bitset(ibitmap,i);
         bitmap = bmb->build(ibitmap, n);
         delete [] ibitmap;
 

--- a/tutorial/src/BitSequenceRGExample.cpp
+++ b/tutorial/src/BitSequenceRGExample.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     cout << "bit at position " << i << ": ";
     cin >> b;
     if(b==0) bitclean(bs,i);
-    else bitset(bs,i);
+    else cds_utils::bitset(bs,i);
   }
   BitSequenceRG * bsrg = new BitSequenceRG(bs,N,20);
   cout << "rank(" << N/2 << ")=" << bsrg->rank1(N/2) << endl;

--- a/tutorial/src/BitSequenceRRRExample.cpp
+++ b/tutorial/src/BitSequenceRRRExample.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     cout << "bit at position " << i << ": ";
     cin >> b;
     if(b==0) bitclean(bs,i);
-    else bitset(bs,i);
+    else cds_utils::bitset(bs,i);
   }
   BitSequenceRRR * bsrrr = new BitSequenceRRR(bs,N,16);
   cout << "rank(" << N/2 << ")=" << bsrrr->rank1(N/2) << endl;

--- a/tutorial/src/BitSequenceSDArrayExample.cpp
+++ b/tutorial/src/BitSequenceSDArrayExample.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     cout << "bit at position " << i << ": ";
     cin >> b;
     if(b==0) bitclean(bs,i);
-    else bitset(bs,i);
+    else cds_utils::bitset(bs,i);
   }
   BitSequenceSDArray * bss = new BitSequenceSDArray(bs,N);
   cout << "rank(" << N/2 << ")=" << bss->rank1(N/2) << endl;

--- a/tutorial/ssa/ssa.cpp
+++ b/tutorial/ssa/ssa.cpp
@@ -243,14 +243,14 @@ void ssa::build_bwt() {
   for(uint i=0;i<n+1;i++) {
     if(_sa[i]%samplesuff==0) {
       suff_sample[j++]=_sa[i];
-      bitset(sampled_vector,i);
+      cds_utils::bitset(sampled_vector,i);
     }
     if(_sa[i]%samplepos==0) {
       pos_sample[_sa[i]/samplepos]=i;
     }
   }
   pos_sample[n/samplepos+1]=pos_sample[0];
-  bitset(sampled_vector,n+1);
+  cds_utils::bitset(sampled_vector,n+1);
   sampled = new BitSequenceRRR(sampled_vector,n+1,32);
   delete [] sampled_vector;
   delete [] _sa;

--- a/tutorial/ssa/ssa.cpp
+++ b/tutorial/ssa/ssa.cpp
@@ -275,7 +275,7 @@ uint ssa::locate(uchar * pattern, uint m, uint ** occs) {
   assert(m>0);
   assert(pattern!=NULL);
   assert(bwt!=NULL);
-  ulong i=m-1;
+  unsigned long i=m-1;
   uint c = pattern[i]; 
   uint sp = occ[c];
   uint ep = occ[c+1]-1;
@@ -317,7 +317,7 @@ uint ssa::count(uchar * pattern, uint m) {
   assert(m>0);
   assert(pattern!=NULL);
   assert(bwt!=NULL);
-  ulong i=m-1;
+  unsigned long i=m-1;
   uint c = pattern[i]; 
   uint sp = occ[c];
   uint ep = occ[c+1]-1;


### PR DESCRIPTION
This pull request fixes the build on OSX 10.9, which was broken because:
- `bitset` is already defined in `XcodeDefault.xctoolchain/usr/lib/c++/v1/bitset` (#12)
- `ulong` is not understood by the compiler
